### PR TITLE
Fix: Updated to run the test cases and chef style on ruby 3.3

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.2"]
+        ruby: ["3.3"]
     name: Chefstyle on Ruby ${{ matrix.ruby }}
     steps:
       - name: Checkout code
@@ -66,7 +66,7 @@ jobs:
       BUNDLE_WITHOUT: ${{ inputs.bundle_without }}
     strategy:
       matrix:
-        ruby: ["3.1", "3.2"]
+        ruby: ["3.1", "3.2", "3.3"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please describe what this change achieves

- Updated to run chefstyle with ruby 3.3
- Updated to run unit test cases with ruby 3.3

## Issues Resolved

Upgrade the test-kitchen and test-kitchen gems to Ruby 3.3
