### PR TITLE
fix: remove ruby 3.4 from unit tests

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -75,7 +75,7 @@ jobs:
       BUNDLE_WITHOUT: ${{ inputs.bundle_without }}
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.2", "3.3"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

removes ruby 3.4 from unit testing

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
